### PR TITLE
Allow to pass query settings via server URI in Web UI

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -367,7 +367,7 @@
         const server_address = document.getElementById('url').value;
 
         const url = server_address +
-            (~server_address.indexOf('?') ? '&' : '?') + 
+            (server_address.indexOf('?') >= 0 ? '&' : '?') + 
             /// Ask server to allow cross-domain requests.
             'add_http_cors_header=1' +
             '&user=' + encodeURIComponent(user) +

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -361,23 +361,22 @@
 
     function postImpl(posted_request_num, query)
     {
-        /// TODO: Check if URL already contains query string (append parameters).
+        const user = document.getElementById('user').value;
+        const password = document.getElementById('password').value;
 
-        let user = document.getElementById('user').value;
-        let password = document.getElementById('password').value;
+        const server_address = document.getElementById('url').value;
 
-        let server_address = document.getElementById('url').value;
-
-        let url = server_address +
+        const url = server_address +
+            (~server_address.indexOf('?') ? '&' : '?') + 
             /// Ask server to allow cross-domain requests.
-            '?add_http_cors_header=1' +
+            'add_http_cors_header=1' +
             '&user=' + encodeURIComponent(user) +
             '&password=' + encodeURIComponent(password) +
             '&default_format=JSONCompact' +
             /// Safety settings to prevent results that browser cannot display.
             '&max_result_rows=1000&max_result_bytes=10000000&result_overflow_mode=break';
 
-        let xhr = new XMLHttpRequest;
+        const xhr = new XMLHttpRequest;
 
         xhr.open('POST', url, true);
 
@@ -391,12 +390,12 @@
                 /// The query is saved in browser history (in state JSON object)
                 /// as well as in URL fragment identifier.
                 if (query != previous_query) {
-                    let state = {
+                    const state = {
                         query: query,
                         status: this.status,
                         response: this.response.length > 100000 ? null : this.response  /// Lower than the browser's limit.
                     };
-                    let title = "ClickHouse Query: " + query;
+                    const title = "ClickHouse Query: " + query;
 
                     let history_url = window.location.pathname + '?user=' + encodeURIComponent(user);
                     if (server_address != location.origin) {


### PR DESCRIPTION
Allow to pass query settings via server URI

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to pass query settings via server URI in Web UI.
